### PR TITLE
chore: use paid for web platform deployment

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -43,9 +43,9 @@ jobs:
             GEOCODE_API_KEY: '${{ secrets.GEOCODE_API_KEY }}'
           };" > web/env.js
 
-      # Build the Flutter web project
+      # Build the Flutter web project (Paid Version)
       - name: Build Flutter Web
-        run: flutter build web --release
+        run: flutter build web --release --dart-define=APP_FLAVOR=paid
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -46,9 +46,9 @@ jobs:
             GEOCODE_API_KEY: '${{ secrets.GEOCODE_API_KEY }}'
           };" > web/env.js
 
-      # Build the Flutter web project
+      # Build the Flutter web project (Paid Version)
       - name: Build Flutter Web
-        run: flutter build web --release
+        run: flutter build web --release --dart-define=APP_FLAVOR=paid
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
### Changes Made

- Use paid version for firebase web deployment
   - run with `flutter build web --release --dart-define=APP_FLAVOR=paid`