### PR TITLE
refactor: wrap kIsWeb in AppService for testability

### DIFF
--- a/lib/app_root.dart
+++ b/lib/app_root.dart
@@ -14,6 +14,7 @@ import 'package:storyzz/core/providers/app_provider.dart';
 import 'package:storyzz/core/providers/auth_provider.dart';
 import 'package:storyzz/core/providers/settings_provider.dart';
 import 'package:storyzz/core/providers/story_provider.dart';
+import 'package:storyzz/core/utils/constants.dart';
 import 'package:storyzz/features/map/provider/map_provider.dart';
 import 'package:storyzz/features/upload_story/presentation/providers/upload_location_loading_provider.dart';
 import 'package:storyzz/features/upload_story/presentation/providers/upload_map_controller_provider.dart';
@@ -31,7 +32,13 @@ class AppRoot extends StatelessWidget {
     return MultiProvider(
       providers: [
         Provider(create: (_) => SettingRepository(prefs)),
-        Provider(create: (_) => ApiServices(httpClient: http.Client())),
+        Provider(
+          create:
+              (_) => ApiServices(
+                httpClient: http.Client(),
+                appService: AppService(),
+              ),
+        ),
         Provider(create: (_) => MapsApiService(httpClient: http.Client())),
         Provider(
           create:
@@ -55,7 +62,10 @@ class AppRoot extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create:
-              (context) => UploadStoryProvider(context.read<StoryRepository>()),
+              (context) => UploadStoryProvider(
+                storyRepository: context.read<StoryRepository>(),
+                appService: AppService(),
+              ),
         ),
         ChangeNotifierProvider(
           create: (context) => StoryProvider(context.read<StoryRepository>()),

--- a/lib/core/data/networking/services/api_services.dart
+++ b/lib/core/data/networking/services/api_services.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show kIsWeb, Uint8List;
+import 'package:flutter/foundation.dart' show Uint8List;
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 import 'package:path/path.dart' as path;
@@ -10,6 +10,7 @@ import 'package:storyzz/core/data/networking/responses/general_response.dart';
 import 'package:storyzz/core/data/networking/responses/login_response.dart';
 import 'package:storyzz/core/data/networking/responses/stories_response.dart';
 import 'package:storyzz/core/data/networking/utils/api_utils.dart';
+import 'package:storyzz/core/utils/constants.dart';
 
 /// A service class responsible for handling API interactions, such as login, registration,
 /// fetching stories, and uploading stories to the server.
@@ -19,8 +20,9 @@ import 'package:storyzz/core/data/networking/utils/api_utils.dart';
 class ApiServices {
   static const String _baseUrl = "https://story-api.dicoding.dev/v1";
   final http.Client httpClient;
+  final AppService appService;
 
-  ApiServices({required this.httpClient});
+  ApiServices({required this.httpClient, required this.appService});
 
   /// Logs the user in with the provided email and password.
   ///
@@ -174,7 +176,7 @@ class ApiServices {
       final extension = path.extension(fileName).toLowerCase();
       final mime = MediaType('image', _getImageMimeType(extension));
 
-      if (kIsWeb && photoBytes != null) {
+      if (appService.getKIsWeb() && photoBytes != null) {
         final multipart = http.MultipartFile.fromBytes(
           'photo',
           photoBytes,

--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -1,1 +1,9 @@
+import 'package:flutter/foundation.dart';
+
 int tabletBreakpoint = 600;
+
+class AppService {
+  bool getKIsWeb() {
+    return kIsWeb;
+  }
+}

--- a/lib/features/upload_story/presentation/providers/upload_story_provider.dart
+++ b/lib/features/upload_story/presentation/providers/upload_story_provider.dart
@@ -4,6 +4,7 @@ import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:storyzz/core/data/repository/story_repository.dart';
+import 'package:storyzz/core/utils/constants.dart';
 
 /// Manages state for uploading user stories, including image selection and camera usage.
 ///
@@ -15,9 +16,13 @@ import 'package:storyzz/core/data/repository/story_repository.dart';
 ///
 /// Uses [StoryRepository] to perform the actual upload.
 class UploadStoryProvider extends ChangeNotifier {
-  final StoryRepository _storyRepository;
+  final StoryRepository storyRepository;
+  final AppService appService;
 
-  UploadStoryProvider(this._storyRepository);
+  UploadStoryProvider({
+    required this.storyRepository,
+    required this.appService,
+  });
 
   // state properties
   bool _isLoading = false;
@@ -115,7 +120,7 @@ class UploadStoryProvider extends ChangeNotifier {
     _isSuccess = false;
     notifyListeners();
 
-    final result = await _storyRepository.uploadStory(
+    final result = await storyRepository.uploadStory(
       token: token,
       description: description,
       photoFile: photoFile,
@@ -142,7 +147,7 @@ class UploadStoryProvider extends ChangeNotifier {
     double? lat,
     double? lon,
   }) async {
-    if (kIsWeb) {
+    if (appService.getKIsWeb()) {
       final bytes = await imageFile.readAsBytes();
       return uploadStory(
         token: token,

--- a/lib/features/upload_story/presentation/screen/upload_story_screen.dart
+++ b/lib/features/upload_story/presentation/screen/upload_story_screen.dart
@@ -1,6 +1,3 @@
-// file: lib/features/story/presentation/screens/upload_story_screen.dart
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
@@ -8,6 +5,7 @@ import 'package:storyzz/core/localization/l10n/app_localizations.dart';
 import 'package:storyzz/core/navigation/app_router.dart';
 import 'package:storyzz/core/providers/auth_provider.dart';
 import 'package:storyzz/core/providers/story_provider.dart';
+import 'package:storyzz/core/utils/constants.dart';
 import 'package:storyzz/core/variant/build_configuration.dart';
 import 'package:storyzz/features/upload_story/presentation/providers/upload_story_provider.dart';
 import 'package:storyzz/features/upload_story/presentation/widgets/camera_web_view.dart';
@@ -40,6 +38,7 @@ class _UploadStoryScreenState extends State<UploadStoryScreen> {
   late UploadStoryProvider _uploadStoryProvider;
   final TextEditingController _captionController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
+  final AppService _appService = AppService();
 
   @override
   void initState() {
@@ -72,7 +71,7 @@ class _UploadStoryScreenState extends State<UploadStoryScreen> {
   }
 
   Future<void> _handleCameraButton() async {
-    if (kIsWeb) {
+    if (_appService.getKIsWeb()) {
       await _cameraService.handleWebCamera();
     } else {
       await _imagePickerService.pickImage(ImageSource.camera);
@@ -173,6 +172,7 @@ class _UploadStoryScreenState extends State<UploadStoryScreen> {
     final imageFile = uploadProvider.imageFile;
     final isUploading = uploadProvider.isLoading;
     final showCamera = uploadProvider.showCamera;
+    final AppService appService = AppService();
 
     // get build-time constant for web platform
     final appFlavor = const String.fromEnvironment(
@@ -260,7 +260,7 @@ class _UploadStoryScreenState extends State<UploadStoryScreen> {
                       // build variant for android
                       // and
                       // build-time constants for web platform
-                      if (kIsWeb) ...[
+                      if (appService.getKIsWeb()) ...[
                         if (isPaidVersion)
                           StatefulBuilder(
                             builder: (

--- a/lib/features/upload_story/presentation/widgets/image_preview.dart
+++ b/lib/features/upload_story/presentation/widgets/image_preview.dart
@@ -1,12 +1,10 @@
-// file: lib/features/story/presentation/widgets/image_preview.dart
-
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:storyzz/core/localization/l10n/app_localizations.dart';
+import 'package:storyzz/core/utils/constants.dart';
 import 'package:storyzz/features/upload_story/presentation/providers/upload_story_provider.dart';
 
 /// Widget as image preview to shows selected image
@@ -97,6 +95,8 @@ class ImagePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final AppService appService = AppService();
+
     if (imageFile == null) {
       return _buildImagePlaceholder(context);
     }
@@ -116,7 +116,7 @@ class ImagePreview extends StatelessWidget {
       ),
       clipBehavior: Clip.antiAlias,
       child:
-          kIsWeb
+          appService.getKIsWeb()
               ? Image.network(imageFile!.path)
               : Image.file(File(imageFile!.path)),
     );

--- a/lib/features/upload_story/services/camera_service.dart
+++ b/lib/features/upload_story/services/camera_service.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:developer' show log;
 
 import 'package:camera/camera.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:storyzz/core/localization/l10n/app_localizations.dart';
+import 'package:storyzz/core/utils/constants.dart';
 import 'package:storyzz/features/upload_story/presentation/providers/upload_story_provider.dart';
 import 'package:storyzz/features/upload_story/utils/web_utils.dart';
 
@@ -15,6 +15,7 @@ class CameraService {
   late final WebUtils _webUtils = WebUtils();
   late AppLocalizations _localizations;
   late UploadStoryProvider _uploadStoryProvider;
+  final AppService appService = AppService();
 
   void initialize(BuildContext context) {
     _context = context;
@@ -38,7 +39,7 @@ class CameraService {
   }
 
   Future<void> handleWebCamera() async {
-    if (!kIsWeb || _context == null) return;
+    if (!appService.getKIsWeb() || _context == null) return;
 
     final context = _context!;
 

--- a/lib/features/upload_story/services/image_picker_services.dart
+++ b/lib/features/upload_story/services/image_picker_services.dart
@@ -5,10 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:storyzz/core/localization/l10n/app_localizations.dart';
+import 'package:storyzz/core/utils/constants.dart';
 import 'package:storyzz/features/upload_story/presentation/providers/upload_story_provider.dart';
 
 class ImagePickerService {
   final ImagePicker _picker = ImagePicker();
+  final AppService appService = AppService();
   BuildContext? _context;
 
   void initialize(BuildContext context) {
@@ -34,7 +36,7 @@ class ImagePickerService {
       if (pickedFile != null) {
         int fileSize = 0;
 
-        if (kIsWeb) {
+        if (appService.getKIsWeb()) {
           // Web: use `readAsBytes()` to get size
           Uint8List bytes = await pickedFile.readAsBytes();
           fileSize = bytes.lengthInBytes;

--- a/lib/features/upload_story/utils/web_utils.dart
+++ b/lib/features/upload_story/utils/web_utils.dart
@@ -7,12 +7,14 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:storyzz/core/localization/l10n/app_localizations.dart';
+import 'package:storyzz/core/utils/constants.dart';
 import 'package:storyzz/features/upload_story/presentation/providers/upload_story_provider.dart';
 import 'package:universal_html/html.dart' as html;
 
 class WebUtils {
   bool isMobileChrome() {
-    if (!kIsWeb) return false;
+    final AppService appService = AppService();
+    if (!appService.getKIsWeb()) return false;
 
     try {
       final userAgent = html.window.navigator.userAgent.toLowerCase();

--- a/test/core/data/networking/services/api_services_test.dart
+++ b/test/core/data/networking/services/api_services_test.dart
@@ -1,4 +1,3 @@
-// filepath: d:\pem\Dart\Flutter\intermediate\submission\storyzz\test\core\data\networking\services\api_services_test.dart
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -17,6 +16,9 @@ import '../../../../tetsutils/mock.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  final mockFile = MockFile();
+  late MockAppService mockAppService;
   late MockHttpClient mockHttpClient;
   late ApiServices apiServices;
   const baseUrl = "https://story-api.dicoding.dev/v1";
@@ -29,9 +31,16 @@ void main() {
 
   setUp(() {
     mockHttpClient = MockHttpClient();
-    apiServices = ApiServices(httpClient: mockHttpClient);
+    mockAppService = MockAppService();
+    apiServices = ApiServices(
+      httpClient: mockHttpClient,
+      appService: mockAppService,
+    );
     registerFallbackValue(Uri());
     registerFallbackValue(http.Request('POST', Uri.parse('')));
+    registerFallbackValue(http.Request('POST', Uri()));
+    registerFallbackValue(http.MultipartRequest('POST', Uri()));
+    registerFallbackValue(MockStreamedResponse());
   });
 
   group('ApiServices', () {
@@ -250,6 +259,18 @@ void main() {
         'message': 'Story uploaded successfully',
       };
 
+      setUp(() {
+        when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+          final bodyBytes = utf8.encode(jsonEncode(mockResponseSuccess));
+          return http.StreamedResponse(
+            Stream.fromIterable([bodyBytes]), // Use a proper stream
+            201,
+            contentLength: bodyBytes.length,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+      });
+
       test(
         'should return GeneralResponse on successful upload (web)',
         () async {
@@ -281,7 +302,7 @@ void main() {
         () async {
           final mockJsonResponse = jsonEncode(mockResponseSuccess);
 
-          final mockFile = MockFile();
+          when(() => mockAppService.getKIsWeb()).thenReturn(false);
           when(
             () => mockFile.openRead(),
           ).thenAnswer((_) => Stream.value(Uint8List(0)));
@@ -322,13 +343,128 @@ void main() {
         },
       );
 
-      test('should return error message on failed upload', () async {
-        final mockResponse = {'error': true, 'message': 'Upload failed'};
+      test(
+        'should return error message on failed upload',
+        () async {
+          final mockResponse = {'error': true, 'message': 'Upload failed'};
 
+          when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+            return http.StreamedResponse(
+              ByteStream.fromBytes(utf8.encode(jsonEncode(mockResponse))),
+              400,
+            );
+          });
+
+          final result = await apiServices.uploadStory(
+            token: token,
+            description: description,
+            photoBytes: photoBytes,
+            fileName: fileName,
+          );
+
+          expect(result, isA<ApiResult<GeneralResponse>>());
+          expect(result.data, isNull);
+          expect(result.message, 'Upload failed');
+        },
+        skip: !mockAppService.getKIsWeb(),
+      );
+
+      test(
+        'should include lat and lon in the request when provided (web)',
+        () async {
+          final lat = 1.0;
+          final lon = 2.0;
+
+          when(() => mockAppService.getKIsWeb()).thenReturn(true);
+          reset(mockHttpClient);
+          when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+            final bodyBytes = utf8.encode(jsonEncode(mockResponseSuccess));
+            return http.StreamedResponse(
+              Stream.fromIterable([bodyBytes]),
+              201,
+              contentLength: bodyBytes.length,
+              headers: {'content-type': 'application/json'},
+            );
+          });
+
+          final result = await apiServices.uploadStory(
+            token: token,
+            description: description,
+            photoBytes: photoBytes,
+            fileName: fileName,
+            lat: lat,
+            lon: lon,
+          );
+
+          expect(result.data, isNotNull);
+          expect(result.message, isNull);
+
+          final capturedRequest =
+              verify(() => mockHttpClient.send(captureAny())).captured.single
+                  as http.MultipartRequest;
+          expect(capturedRequest.fields['lat'], equals(lat.toString()));
+          expect(capturedRequest.fields['lon'], equals(lon.toString()));
+        },
+      );
+
+      test(
+        'should include lat and lon in the request when provided (mobile)',
+        () async {
+          final lat = 1.0;
+          final lon = 2.0;
+          final mockFile = MockFile();
+
+          when(() => mockAppService.getKIsWeb()).thenReturn(false);
+          when(
+            () => mockFile.openRead(),
+          ).thenAnswer((_) => Stream.value(Uint8List(0)));
+          when(() => mockFile.length()).thenAnswer((_) async => 100);
+          when(() => mockFile.path).thenReturn('test.jpg');
+
+          reset(mockHttpClient);
+
+          when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+            final bodyBytes = utf8.encode(jsonEncode(mockResponseSuccess));
+            return http.StreamedResponse(
+              Stream.fromIterable([bodyBytes]),
+              201,
+              contentLength: bodyBytes.length,
+              headers: {'content-type': 'application/json'},
+            );
+          });
+
+          // Call the method being tested with photoFile ONLY
+          final result = await apiServices.uploadStory(
+            token: token,
+            description: description,
+            photoFile: mockFile, // Only include photoFile
+            fileName: fileName,
+            lat: lat,
+            lon: lon,
+          );
+
+          expect(result.data, isNotNull);
+          expect(result.message, isNull);
+
+          final capturedRequest =
+              verify(() => mockHttpClient.send(captureAny())).captured.single
+                  as http.MultipartRequest;
+          expect(capturedRequest.fields['lat'], equals(lat.toString()));
+          expect(capturedRequest.fields['lon'], equals(lon.toString()));
+        },
+      );
+
+      test('should send photoBytes in request when provided (web)', () async {
+        reset(mockHttpClient);
+
+        when(() => mockAppService.getKIsWeb()).thenReturn(true);
         when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+          final bodyBytes = utf8.encode(jsonEncode(mockResponseSuccess));
           return http.StreamedResponse(
-            ByteStream.fromBytes(utf8.encode(jsonEncode(mockResponse))),
-            400,
+            Stream.fromIterable([bodyBytes]),
+            201,
+            contentLength: bodyBytes.length,
+            headers: {'content-type': 'application/json'},
           );
         });
 
@@ -339,10 +475,135 @@ void main() {
           fileName: fileName,
         );
 
-        expect(result, isA<ApiResult<GeneralResponse>>());
-        expect(result.data, isNull);
-        expect(result.message, 'Upload failed');
-      }, skip: !kIsWeb);
+        expect(result.data, isNotNull);
+
+        final capturedRequest =
+            verify(() => mockHttpClient.send(captureAny())).captured.single
+                as http.MultipartRequest;
+        expect(capturedRequest.files.length, 1);
+        expect(capturedRequest.files.first.field, 'photo');
+        expect(capturedRequest.files.first.filename, fileName);
+      });
+
+      test('should throw an exception if no image data is provided', () async {
+        when(() => mockAppService.getKIsWeb()).thenReturn(false);
+        when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+          final bodyBytes = utf8.encode(jsonEncode(mockResponseSuccess));
+          return http.StreamedResponse(
+            Stream.fromIterable([bodyBytes]),
+            201,
+            contentLength: bodyBytes.length,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+        final result = await apiServices.uploadStory(
+          token: token,
+          description: description,
+          fileName: fileName,
+        );
+        expect(result.message, contains('No image data provided'));
+      });
+
+      test(
+        'should capture FormatException in ApiResult when JSON is invalid',
+        () async {
+          const description = 'Test description';
+          final photoBytes = Uint8List.fromList([1, 2, 3]);
+          const fileName = 'test.jpg';
+
+          reset(mockHttpClient);
+
+          when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+            return http.StreamedResponse(
+              Stream.fromIterable([utf8.encode('This is not valid JSON')]),
+              201, // Success status code
+              contentLength: 'This is not valid JSON'.length,
+              headers: {'content-type': 'text/plain'}, // Not JSON content type
+            );
+          });
+
+          final result = await apiServices.uploadStory(
+            token: token,
+            description: description,
+            photoBytes: photoBytes,
+            photoFile: mockFile,
+            fileName: fileName,
+          );
+
+          expect(result.data, isNull);
+          expect(
+            result.message,
+            contains('Unexpected data type encountered. Please try again.'),
+          );
+        },
+      );
+
+      test('should return error message for server error', () async {
+        final errorResponseBody = jsonEncode({
+          "error": true,
+          "message": "Invalid file format",
+        });
+
+        when(() => mockAppService.getKIsWeb()).thenReturn(true);
+        when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+          final bodyBytes = utf8.encode(errorResponseBody);
+          return http.StreamedResponse(
+            Stream.value(bodyBytes),
+            400,
+            headers: {'content-type': 'application/json'},
+            contentLength: bodyBytes.length,
+          );
+        });
+
+        when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+          final bodyBytes = utf8.encode(errorResponseBody);
+          return http.StreamedResponse(
+            Stream.value(bodyBytes),
+            400,
+            headers: {'content-type': 'application/json'},
+            contentLength: bodyBytes.length,
+          );
+        });
+
+        final result = await apiServices.uploadStory(
+          token: token,
+          description: description,
+          photoBytes: photoBytes,
+          fileName: fileName,
+          lat: 1.0,
+          lon: 2.0,
+        );
+
+        expect(result.message, equals("Invalid file format"));
+        verify(() => mockHttpClient.send(any())).called(1);
+      });
+
+      test('should handle non-JSON error responses', () async {
+        final errorResponseBody = "Internal Server Error";
+
+        when(() => mockAppService.getKIsWeb()).thenReturn(true);
+        when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+          final bodyBytes = utf8.encode(errorResponseBody);
+          return http.StreamedResponse(
+            Stream.value(bodyBytes),
+            500,
+            headers: {'content-type': 'text/plain'},
+            contentLength: bodyBytes.length,
+          );
+        });
+
+        final result = await apiServices.uploadStory(
+          token: token,
+          description: description,
+          photoBytes: photoBytes,
+          fileName: fileName,
+          lat: 1.0,
+          lon: 2.0,
+        );
+
+        expect(result.message, equals("Server error: Status code 500"));
+        verify(() => mockHttpClient.send(any())).called(1);
+      });
     });
   });
 }

--- a/test/tetsutils/mock.dart
+++ b/test/tetsutils/mock.dart
@@ -19,6 +19,7 @@ import 'package:storyzz/core/providers/app_provider.dart';
 import 'package:storyzz/core/providers/auth_provider.dart';
 import 'package:storyzz/core/providers/settings_provider.dart';
 import 'package:storyzz/core/providers/story_provider.dart';
+import 'package:storyzz/core/utils/constants.dart';
 import 'package:storyzz/core/utils/environment.dart';
 import 'package:storyzz/features/map/provider/map_provider.dart';
 import 'package:storyzz/features/upload_story/presentation/providers/upload_story_provider.dart';
@@ -93,3 +94,7 @@ class MockBuildContext extends Mock implements BuildContext {}
 class MockUser extends Mock implements User {}
 
 class MockSharedPreferences extends Mock implements SharedPreferences {}
+
+class MockAppService extends Mock implements AppService {}
+
+class MockStreamedResponse extends Mock implements http.StreamedResponse {}


### PR DESCRIPTION
### Changes Made

- Added `AppService.getKIsWeb()` as a wrapper for `kIsWeb`
- This enables mocking platform checks in unit and widget tests
- Updated relevant usages to use the new method