### PR TITLE
chore(ci/cd): upgrade flutter action to v2.20.0

### DIFF
--- a/.github/workflows/flutter_ci_cd.yml
+++ b/.github/workflows/flutter_ci_cd.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Set up Flutter
-        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
+        uses: subosito/flutter-action@395322a6cded4e9ed503aebd4cc1965625f8e59a
         with:
           channel: stable
           flutter-version: 3.32.0


### PR DESCRIPTION
### Changes Made

- Upgrade flutter action to [`v2.20.0`](https://github.com/subosito/flutter-action/releases/tag/v2.20.0)