### PR TITLE
fix(ci): use Node 24.18.0 for firebase deploy

### DIFF
--- a/.github/workflows/flutter_ci_cd.yml
+++ b/.github/workflows/flutter_ci_cd.yml
@@ -307,6 +307,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24.18.0"
       
       - name: Set up Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
@@ -353,6 +357,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24.18.0"
       
       - name: Set up Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2


### PR DESCRIPTION
### Changes Made

- Use Node `24.18.0` for firebase deploy


### Reference

- https://github.com/firebase/firebase-tools/issues/10716#issuecomment-4800040219