### PR TITLE
chore: migrate Flutter Android projects to built-in Kotlin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,7 +9,6 @@ if (secretsPropertiesFile.exists()) {
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -19,14 +18,9 @@ android {
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -53,8 +47,10 @@ android {
             signingConfig = signingConfigs.getByName("debug")
         }
     }
+
     buildFeatures {
         buildConfig = true
+        resValues = true
     }
 
     flavorDimensions += "tier"
@@ -71,6 +67,12 @@ android {
             resValue("string", "app_name", "Storyzz Premium")
             buildConfigField("boolean", "IS_PAID_VERSION", "true")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,9 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false
+# Disable Kotlin incremental compilation to fix cross-drive path issue
+kotlin.incremental=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.13.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("com.android.application") version "9.0.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 include(":app")


### PR DESCRIPTION
### Changes Made

- Migrate Flutter Android projects to built-in Kotlin
- Bump Gradle to [v9.1.0](https://github.com/gradle/gradle/releases/tag/v9.1.0)
- Bump AGP to [v9.0.1](https://developer.android.com/build/releases/agp-9-0-0-release-notes)
- Bump Kotlin to [v2.3.20](https://github.com/JetBrains/kotlin/releases/tag/v2.3.20)

### Reference

- https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers