### PR TITLE
chore: remove redundant platform-specific dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -569,7 +569,7 @@ packages:
     source: hosted
     version: "2.17.1"
   google_maps_flutter_android:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: google_maps_flutter_android
       sha256: a404c67d460f64b8bdc48aa5e39c81aa13505552d8783ae68f9aeef074913286
@@ -593,7 +593,7 @@ packages:
     source: hosted
     version: "2.15.0"
   google_maps_flutter_web:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: google_maps_flutter_web
       sha256: e23f2869449bb3e2ed7cfdb178d716e1da7edc684363987e4cb2c42f2bd7a9e0
@@ -673,7 +673,7 @@ packages:
     source: hosted
     version: "0.8.13+17"
   image_picker_for_web:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: image_picker_for_web
       sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,6 @@ dependencies:
 
   # camera and image picker deps
   image_picker: ^1.2.3
-  image_picker_for_web: ^3.1.1
   path: ^1.9.1
   camera: ^0.12.0+1
   image: ^4.9.1
@@ -47,8 +46,6 @@ dependencies:
 
   # location
   google_maps_flutter: ^2.17.1
-  google_maps_flutter_web: ^0.6.2+3
-  google_maps_flutter_android: ^2.19.12
   geolocator: ^14.0.3
   geocoding: ^5.0.0
 


### PR DESCRIPTION
### Changes Made

- Remove `google_maps_flutter_web`
- Remove `google_maps_flutter_android`
- Remove `image_picker_for_web`